### PR TITLE
Change to use shell than file module to bypass the ansible issue 50638

### DIFF
--- a/roles/fetch-zuul-cloner/tasks/main.yaml
+++ b/roles/fetch-zuul-cloner/tasks/main.yaml
@@ -16,10 +16,7 @@
     mode: 0755
   become: yes
 
+# workaround of the ansible bug: https://github.com/ansible/ansible/issues/50638
 - name: Make repositories writable so that people can hardlink
-  file:
-    path: "{{ ansible_user_dir }}/src"
-    state: directory
-    recurse: yes
-    mode: ugo+rw
+  shell: chmod ugo+rw "{{ ansible_user_dir }}/src" -R
   become: yes


### PR DESCRIPTION
Ansible `file` module will fail when it handle source code of project that include soft-link file, so we have to workaround at here

Related-Bug: ansible/ansible#50638
Closes: theopenlab/openlab#153